### PR TITLE
@@iterator and into implementation

### DIFF
--- a/lib/identity.js
+++ b/lib/identity.js
@@ -9,12 +9,28 @@ function Identity(val) {
 
 
 Identity.prototype['@@transducer/init'] = function() {
+  return Identity();
 };
 
 Identity.prototype['@@transducer/step'] = function(acc, item) {
+  return Identity(item);
 };
 
 Identity.prototype['@@transducer/result'] = function(result) {
+  return result;
+};
+
+Identity.prototype['@@iterator'] = function() {
+  var didIt = false, that = this;
+  return {
+    next: function(){
+      if(didIt){
+        return {done: true};
+      }
+      didIt = true;
+      return {done: false, value: that.extract()};
+    }
+  };
 };
 
 Identity.prototype.extract = function() {

--- a/test/identity-test.js
+++ b/test/identity-test.js
@@ -11,7 +11,7 @@ describe('Identity', function() {
   });
 
   it('can be mapped over', function() {
-    var result = R.map(R.add(1), Identity(1));
+    var result = R.into(Identity(), R.map(R.add(1)), Identity(1));
     result.extract().should.equal(2);
   });
 


### PR DESCRIPTION
Here's an option: 
- I implemented the iterator protocol to send the single value
- Step just wraps the item, ignoring previous result
- Uses `into` in test to force iteration

Note that `R.map(R.add(1), Identity(1))` is just going to create a transformer, not force an iteration.
